### PR TITLE
Add back utils package to fix dependent pkgs

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// nodigits defines a regexp for matching non-digits.
+var nodigits = regexp.MustCompile("[^\\d\\.]+")
+
+// ParseFloat parses a string into a float if fails returns the default value 0.
+func ParseFloat(fl string) float64 {
+	fll, _ := strconv.ParseFloat(DigitsOnly(fl), 64)
+	return fll
+}
+
+// ParseInt parses a string into a int if fails returns the default value 0.
+func ParseInt(fl string) int {
+	fll, _ := strconv.Atoi(DigitsOnly(fl))
+	return fll
+}
+
+// ParseIntBase16 parses a string into a int using base16.
+func ParseIntBase16(fl string) int {
+	fll, _ := strconv.ParseInt(fl, 16, 64)
+	return int(fll)
+}
+
+// DigitsOnly removes all non-digits characters in a string.
+func DigitsOnly(fl string) string {
+	return nodigits.ReplaceAllString(fl, "")
+}


### PR DESCRIPTION
Fixes #7, and also helps ensure Gu compiles (once this change is vendored) -- see: https://github.com/gu-io/gu/issues/38

I couldn't find where the necessary utils function(s) got moved to, so I just added back the old utils package. Maybe you had other plans?